### PR TITLE
chore(deps): bump @ngrx/signals from v19.0.0 to v19.0.1

### DIFF
--- a/libs/ngx-signal-store-query/package.json
+++ b/libs/ngx-signal-store-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-signal-store-query/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Signal Store feature that bridges with Angular Query",
   "keywords": [
     "Angular",
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@angular/common": "^19.0.0 || >=20.0.0 || next",
     "@angular/core": "^19.0.0 || >=20.0.0 || next",
-    "@ngrx/signals": "^19.0.0 || >=20.0.0 || next",
-    "@tanstack/angular-query-experimental": "^5.61.0"
+    "@ngrx/signals": "^19.0.1 || >=20.0.0 || next",
+    "@tanstack/angular-query-experimental": "^5.66.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-signal-store-query/source",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "build": "ng build ngx-signal-store-query --configuration=production",


### PR DESCRIPTION
BREAKING CHANGE: Stopped supporting versions of @ngrx/signals that are older than v19.0.1.

Release-As: 0.6.0